### PR TITLE
fix server rendering not supporting settings page

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -211,6 +211,11 @@ app.get('/@:name', serverSideResponse);
 
 app.get('/:category/@:author/:permlink', serverSideResponse);
 app.get('/search/titles', serverSideResponse);
+
+app.get('/settings', (req, res) => {
+  res.send(indexHtml);
+});
+
 app.get('/:title', serverSideResponse);
 
 app.get('/*', (req, res) => {


### PR DESCRIPTION
/:title was overriding /settings page on server routes. So I indicated it to run client-render if it is settings page.