### PR TITLE
allow header markdown and html tags but decrease their visibility

### DIFF
--- a/src/components/Story/Body.js
+++ b/src/components/Story/Body.js
@@ -77,7 +77,7 @@ export function getHtml(body, jsonMetadata = {}, returnType = 'Object') {
     }
   });
 
-  const options = {ALLOWED_TAGS:  ["br", "blockquote", "img", "link", "a", "p", "iframe", "ul", "ol", "li", "table", "thead", "tr", "td"]};
+  const options = {ALLOWED_TAGS:  ["br", "blockquote", "img", "link", "a", "p", "iframe", "ul", "ol", "li", "table", "thead", "tr", "td", "h1", "h2", "h3", "h4", "h5", "h6"]};
   
   parsedBody = domPurifyImp.sanitize(parsedBody, options);
 

--- a/src/components/Story/Body.less
+++ b/src/components/Story/Body.less
@@ -13,17 +13,17 @@
 
   // Heading
 
+  
   h1,
   h2,
   h3,
-  h4
-  {
-    font-weight: 600;
-  }
+  h4,
   h5,
   h6 {
-    font-weight: 400;
+    font-size:16px;
+    font-weight:600;
   }
+
 
   h1 {
     margin: 2.5rem 0 0.3rem;


### PR DESCRIPTION
as we already have topic names with h1, multiple entries having headers were making confusion. i had removed headers on previous updates. on this commit, i enable them again but decrease their visibility.